### PR TITLE
Fixed EndPage not displaying after video ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Sparsh Gupta, Chang Jun Park and Akshat Jain
 
 ## Dependencies
 
-| Package    | Uses              |
-|------------|-------------------|
-| NumPy      | Array Operations  |
-| OpenCV     | Computer Vision   |
-| Playsound  | Plays sound file  |
-| TensorFlow | Machine Learning  |
+| Package    | Uses                    |
+|------------|-------------------------|
+| NumPy      | Array Operations        |
+| OpenCV     | Computer Vision         |
+| Playsound  | Plays sound file        |
+| TensorFlow | Machine Learning        |
+| Mutagen    | Audio Length Extraction |
 
 
  The dependencies are present in `requirements.txt` and can be installed using the following in terminal/command prompt (make sure to have your present working directory as this repo):

--- a/just_dance_controller.py
+++ b/just_dance_controller.py
@@ -63,7 +63,6 @@ class JustDanceController:
             "left_leg": [],
             "right_leg": [],
         }
-        self.timeout = time.time() + 300
         self.cap1 = cv2.VideoCapture(video_path)
         self.cap2 = cv2.VideoCapture(camera_index)
         self.frame1_rate = self.cap1.get(cv2.CAP_PROP_FPS)
@@ -138,10 +137,6 @@ class JustDanceController:
             if cv2.waitKey(1) & 0xFF == ord("q"):
                 # Exit program if 'q' key is pressed
                 sys.exit()
-
-            if time.time() > self.timeout:
-                print("Timeout reached! Exiting...")
-                break
 
             elapsed_time = time.time() - start_time
             frame_delay = max(1, int(1000 / self.frame1_rate) - int(

--- a/just_dance_main.py
+++ b/just_dance_main.py
@@ -37,7 +37,7 @@ class JustDanceGame:
         self.controller = JustDanceController(
             model=self.model, video_path=video_path, camera_index=camera_index
         )
-        self.score=0
+        self.score = 0
 
     def run(self, song):
         """
@@ -59,7 +59,7 @@ class JustDanceGame:
         self.score = self.model.final_score(
             self.controller.angles_video,
             self.controller.angles_camera,
-            30)
+            20)
 
     def store_leaderboard(self, csv_file):
         """
@@ -70,23 +70,9 @@ class JustDanceGame:
 
         Returns:
             None
-
-        Raises:
-            FileNotFoundError: If there is an error reading or writing the CSV file.
         """
-        # Load the existing scores
-        try:
-            with open(csv_file, "r") as file:
-                reader = csv.reader(file)
-                scores = list(reader)
-        except FileNotFoundError:
-            scores = []
-
-        # Add the new score to the list
-        scores.append([self.score])
-
         # Write scores to the file
-        with open(csv_file, "w", newline="") as file:
+        with open(csv_file, "a", newline="") as file:
             writer = csv.writer(file)
             writer.writerow([self.score])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+mutagen>=1.46.0
 numpy>=1.23.0
 opencv_python>=4.7.0.72
 playsound>=1.3.0


### PR DESCRIPTION
- Removed the 'Play Again' option in GUI because displaying EndPage after more than one run seems very complicated. (not enough time to implement)
- Added new functions & code for displaying ENdPage after one song ends.
- Every other functionality working.
- Fixed leaderboard CSV overwriting.
- Added new dependency for implementing EndPage display to calculate song length